### PR TITLE
BAH-4203 | Add. Bump OpenMRS Core Version v2.5.12 To v2.6.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,9 @@
         </developer>
     </developers>
     <properties>
-        <openmrsPlatformVersion>2.5.12</openmrsPlatformVersion>
-        <openmrsFhir2Version>2.1.0</openmrsFhir2Version>
-        <webServicesVersion>2.44.0</webServicesVersion>
+        <openmrsPlatformVersion>2.6.15</openmrsPlatformVersion>
+        <openmrsFhir2Version>2.5.0</openmrsFhir2Version>
+        <webServicesVersion>2.49.0</webServicesVersion>
         <powerMockVersion>2.0.9</powerMockVersion>
         <mockitoVersion>3.5.11</mockitoVersion>
         <junitVersion>4.13.2</junitVersion>


### PR DESCRIPTION
JIRA → [BAH-4203](https://bahmni.atlassian.net/browse/BAH-4203)

Upgraded OpenMRS dependencies to align with the latest stable releases and improve compatibility.

**Changes**
- OpenMRS Core: 2.5.12 → 2.6.15
- OpenMRS FHIR2 Module: 2.1.0 → 2.5.0
- web.services: 2.44 -> 2.49

**Context**
These upgrades bring in the latest bug fixes, performance improvements, and enhanced FHIR support.